### PR TITLE
fix: avoid built-ins

### DIFF
--- a/src/handlers/issue/comment-scoring-rubric.ts
+++ b/src/handlers/issue/comment-scoring-rubric.ts
@@ -159,10 +159,17 @@ export class CommentScoring {
   ): (typeof CommentScoring.prototype.commentScores)[number]["details"][number]["wordScoreCommentDetails"] {
     const wordScoreCommentDetails: { [key: string]: Decimal } = {};
 
+    const builtIns = new Set(
+      Object.getOwnPropertyNames(Object.prototype).filter((name) => typeof Object.prototype[name] === "function")
+    );
+
     for (const word of words) {
-      let counter = wordScoreCommentDetails[word] || ZERO;
-      counter = counter.plus(this.roleWordScore);
-      wordScoreCommentDetails[word] = counter;
+      if (!builtIns.has(word)) {
+        let counter = wordScoreCommentDetails[word] || ZERO;
+        counter = counter.plus(this.roleWordScore);
+
+        wordScoreCommentDetails[word] = counter;
+      }
     }
 
     return wordScoreCommentDetails;

--- a/src/handlers/tests/scoring-rubric-built-ins.test.ts
+++ b/src/handlers/tests/scoring-rubric-built-ins.test.ts
@@ -1,0 +1,35 @@
+import Decimal from "decimal.js";
+
+describe("Scoring Rubric Built-ins", () => {
+  let wordScoreCommentDetails: { [key: string]: Decimal };
+
+  beforeEach(() => {
+    wordScoreCommentDetails = {};
+  });
+
+  it("should increment counter for non-built-in words", () => {
+    const words = ["hasOwnProperty", "valueOf", "was", "async", "but", "the", "constructor", "isn", "t", "I", "was"];
+    const ZERO = new Decimal(0);
+
+    const builtIns = new Set(
+      Object.getOwnPropertyNames(Object.prototype).filter((name) => typeof Object.prototype[name] === "function")
+    );
+
+    for (const word of words) {
+      if (!builtIns.has(word)) {
+        const counter = wordScoreCommentDetails[word] || ZERO;
+        wordScoreCommentDetails[word] = counter;
+      }
+    }
+
+    expect(wordScoreCommentDetails).toEqual({
+      was: new Decimal(0),
+      async: new Decimal(0),
+      but: new Decimal(0),
+      the: new Decimal(0),
+      isn: new Decimal(0),
+      t: new Decimal(0),
+      I: new Decimal(0),
+    });
+  });
+});

--- a/src/utils/generate-configuration.ts
+++ b/src/utils/generate-configuration.ts
@@ -16,7 +16,7 @@ export async function generateConfiguration(
   const orgConfig = parseYaml(
     await download({
       repository: UBIQUIBOT_CONFIG_REPOSITORY,
-      owner: owner,
+      owner,
       authenticatedOctokit,
     })
   );


### PR DESCRIPTION
Resolves #31

- Built an exclusion list based on object prototype built-ins

QA:

- difficult to QA in a working sense other than below

![image](https://github.com/ubiquibot/comment-incentives/assets/106303466/5eb64800-3710-4633-b17c-6dd7cf128e6b)

```ts

(async () => {
  const wordScoreCommentDetails: { [key: string]: Decimal } = {};
  const words = ["hasOwnProperty", "valueOf", "was", "async", "but", "the", "constructor", "isn", "t", "I", "was"];
  const ZERO = new Decimal(0);

  const builtIns = new Set(
    Object.getOwnPropertyNames(Object.prototype).filter((name) => typeof Object.prototype[name] === "function")
  );

  for (const word of words) {
    if (!builtIns.has(word)) {
      let counter = wordScoreCommentDetails[word] || ZERO;
      wordScoreCommentDetails[word] = counter;
    }
  }

  console.log("scoringDetails: ", wordScoreCommentDetails);
})().catch(console.error);
```