### PR TITLE
fix: lower than and greater than characters are escaped

### DIFF
--- a/src/handlers/issue/generate-permits.ts
+++ b/src/handlers/issue/generate-permits.ts
@@ -242,7 +242,9 @@ function generateDetailsTable(totals: TotalsById) {
         const commentScore = commentScores[index];
 
         const commentUrl = commentSource.comment.html_url;
-        const truncatedBody = commentSource ? commentSource.comment.body.substring(0, 64).concat("...") : "";
+        const truncatedBody = commentSource
+          ? commentSource.comment.body.replaceAll("<", "&lt;").replaceAll(">", "&gt;").substring(0, 64).concat("...")
+          : "";
         const formatScoreDetails = commentScore.formatScoreCommentDetails;
 
         let formatDetailsStr = "";


### PR DESCRIPTION
To avoid being interpreted, `<` and `>` are escaped.

Related issue: https://github.com/ubiquity/work.ubq.fi/issues/47#issuecomment-2130649316