### PR TITLE
fix: escaping ampersand and backtick characters

### DIFF
--- a/src/handlers/issue/generate-permits.ts
+++ b/src/handlers/issue/generate-permits.ts
@@ -243,7 +243,13 @@ function generateDetailsTable(totals: TotalsById) {
 
         const commentUrl = commentSource.comment.html_url;
         const truncatedBody = commentSource
-          ? commentSource.comment.body.replaceAll("<", "&lt;").replaceAll(">", "&gt;").substring(0, 64).concat("...")
+          ? commentSource.comment.body
+              .replaceAll("&", "&amp;")
+              .replaceAll("<", "&lt;")
+              .replaceAll(">", "&gt;")
+              .replaceAll("`", "&#96;")
+              .substring(0, 64)
+              .concat("...")
           : "";
         const formatScoreDetails = commentScore.formatScoreCommentDetails;
 


### PR DESCRIPTION
Relates to https://github.com/ubiquity/pay.ubq.fi/issues/227#issuecomment-2141510292 not being displayed properly.